### PR TITLE
Make sure the last field of a line is read

### DIFF
--- a/csv.lisp
+++ b/csv.lisp
@@ -250,11 +250,7 @@ Be careful to not skip a separator, as it could be e.g. a tab!"
 	   (when *skip-whitespace*
 	     (accept-spaces stream))
 	   ;;#+DEBUG (format t "~&do-field, after spaces~%")
-	   (cond
-	     ((or (accept-eol stream) (accept-eof stream))
-	      (done))
-	     (t
-	      (do-field-start))))
+	   (do-field-start))
 	 (do-field-start ()
 	   ;;#+DEBUG (format t "~&do-field-start~%")
 	   (cond


### PR DESCRIPTION
This commit fixes the following bug:

If the last field of a line was empty, it would not be added to the list
returned by READ-CSV-LINE. The problem was that the check for eol was
performed both at the start of the field and at the end.

The CSV
1,2,3
,2,3
1,,3
1,2,

would produce

``` lisp
(("1" "2" "3") 
 ("" "2" "3") 
 ("1" "" "3") 
 ("1" "2"))
```

whereas it is desirable for each list to have the same number of elements as the csv line that was responsible for its creation.

Thanks,
Panos

PS I am really still a newbie in common lisp, and I hope I have understood correctly how the rest of the code works and this patch doesn't break anything else. I have used this code to read two relatively big CSV files, and everything seems to be working, but I have not tested it extensively. 
